### PR TITLE
Fixed a bug that failed to avoid overwriting globalData

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function BacklinksPlugin(eleventy, options={}) {
 
     eleventy.addGlobalData("eleventyComputed", {
     	// Don't overwrite any existing global computed data
-        ...getExistingData(eleventy.globalData),
+        ...getExistingData(eleventy.globalData).eleventyComputed,
         backlinks(data) {
             if (isNoteFile(data.page.filePathStem) === false) return;
 


### PR DESCRIPTION
Current code was overwriting `eleventyComputed` globalData, so some collection was removed. I fixed the bug.
